### PR TITLE
fix(claude-usage-exporter): price claude-sonnet-5

### DIFF
--- a/claude-usage-exporter/claude-usage-exporter.py
+++ b/claude-usage-exporter/claude-usage-exporter.py
@@ -30,7 +30,7 @@ import time
 from collections import defaultdict
 
 # Base list pricing, $ per 1M tokens (input, output).
-# Source: claude-api skill model table (cached 2026-05-26). Cache rates derived
+# Source: claude-api skill model table (cached 2026-07-03). Cache rates derived
 # from documented multipliers: read 0.1x, write-5m 1.25x, write-1h 2.0x of input.
 PRICING = {
     "claude-fable-5":   (10.0, 50.0),
@@ -38,6 +38,7 @@ PRICING = {
     "claude-opus-4-7":  (5.0, 25.0),
     "claude-opus-4-6":  (5.0, 25.0),
     "claude-opus-4-5":  (5.0, 25.0),
+    "claude-sonnet-5":  (3.0, 15.0),
     "claude-sonnet-4-6": (3.0, 15.0),
     "claude-sonnet-4-5": (3.0, 15.0),
     "claude-haiku-4-5": (1.0, 5.0),


### PR DESCRIPTION
## What & why

`ClaudeUsageUnpricedModel` fired on misaka: `claude-sonnet-5` appeared in Claude Code transcripts on **agentspace** but had no entry in `PRICING`, so its token usage was counted at **\$0** (`claude_code_unpriced_model_info{model="claude-sonnet-5"} = 1`).

## Change

Add `claude-sonnet-5` to `PRICING` at **base list price \$3 / \$15 per MTok**:
- Matches the existing `sonnet-4-6` / `sonnet-4-5` entries and the `PRICING` comment's "Base list pricing" / "API-equivalent list price" semantics.
- Deliberately **not** the introductory \$2/\$10 promo (through 2026-08-31) — the metric tracks list price, and the promo is a temporary discount.
- Verified `\$3/\$15` against the current claude-api skill model table; bumped the source-comment cache date to 2026-07-03.

## Verification

```
normalize_model('claude-sonnet-5')            -> 'claude-sonnet-5'
normalize_model('claude-sonnet-5-20260101')   -> 'claude-sonnet-5'   # dated-snapshot prefix match
PRICING['claude-sonnet-5']                     == (3.0, 15.0)
```

Script imports cleanly; 9 models now priced. Merging to `master` triggers `docker.yml` to rebuild/push the multi-arch image; once agentspace pulls it, `claude_code_usage_exporter_unpriced_models` returns to 0 and the alert clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtPhppYibFUFac2tEiVVRh