### PR TITLE
Price claude-opus-5, and cover the matcher it feeds

### DIFF
--- a/claude-usage-exporter/claude-usage-exporter.py
+++ b/claude-usage-exporter/claude-usage-exporter.py
@@ -42,10 +42,15 @@ import time
 from collections import defaultdict
 
 # Base list pricing, $ per 1M tokens (input, output).
-# Source: claude-api skill model table (cached 2026-07-03). Cache rates derived
-# from documented multipliers: read 0.1x, write-5m 1.25x, write-1h 2.0x of input.
+# Every rate below verified 2026-07-26 against platform.claude.com's models
+# overview. (The claude-api skill's own table is a cache with an older stamp and
+# omits some entries here, so it is not the citable source for this table.)
+# Cache rates derived from documented multipliers: read 0.1x, write-5m 1.25x,
+# write-1h 2.0x of input. Base list pricing - note claude-sonnet-5 carries
+# introductory $2/$10 through 2026-08-31, so its imputed cost reads high until then.
 PRICING = {
     "claude-fable-5":   (10.0, 50.0),
+    "claude-opus-5":    (5.0, 25.0),
     "claude-opus-4-8":  (5.0, 25.0),
     "claude-opus-4-7":  (5.0, 25.0),
     "claude-opus-4-6":  (5.0, 25.0),

--- a/claude-usage-exporter/test_exporter.py
+++ b/claude-usage-exporter/test_exporter.py
@@ -245,6 +245,38 @@ class MonotonicCounterTest(unittest.TestCase):
         models = {k.split("\x1f")[0] for k in state["cost"]}
         self.assertEqual(models, {"claude-haiku-4-5"})
 
+    def test_pricing_keys_are_matcher_safe(self):
+        """No PRICING key may be a prefix of another under normalize_model's
+        `startswith(known + "-")` rule.
+
+        normalize_model iterates PRICING in insertion order and returns the
+        first match, so a key that prefixes a later key would make the later
+        one unreachable - it would silently price under the wrong id and never
+        reach `unpriced`, so ClaudeUsageUnpricedModel could not catch it. This
+        guards the table only; it cannot detect the related hazard of a key
+        shadowing a future model id that is absent from the table (e.g.
+        claude-opus-5 absorbing a future claude-opus-5-1), which needs a
+        stricter suffix rule than dict ordering can express.
+        """
+        keys = list(cue.PRICING)
+        shadowed = [(a, b) for a in keys for b in keys
+                    if a != b and b.startswith(a + "-")]
+        self.assertEqual(shadowed, [], f"PRICING key shadows another: {shadowed}")
+
+    def test_dated_snapshot_of_every_pricing_key_resolves_to_itself(self):
+        """A dated snapshot must normalize back onto its base key.
+
+        Anthropic ships ids both bare and dated (claude-haiku-4-5 /
+        claude-haiku-4-5-20251001). If a key stopped absorbing its own dated
+        form the usage would split across two model labels, one of them
+        unpriced. normalize_model had no direct test coverage before this.
+        """
+        for key in cue.PRICING:
+            if "/" in key:
+                continue  # local OpenRouter ids are not date-snapshotted
+            self.assertEqual(cue.normalize_model(key), key)
+            self.assertEqual(cue.normalize_model(key + "-20260301"), key)
+
     def test_local_lane_alias_priced_under_official_name(self):
         """A legacy local lane name ("smart") must be remapped to the official
         OpenRouter id and priced at its imputed rates, not deferred as unpriced."""


### PR DESCRIPTION
## What this does

Adds `claude-opus-5` to the exporter's `PRICING` table at $5/$25 per MTok, and gives `normalize_model` its first direct test coverage.

## Why it matters

Opus 5 was absent from the table, so its usage was **deferred, not counted at $0** — `update_state` skips those messages *and* leaves them out of the seen-set. That makes the `ClaudeUsageUnpricedModel` alert a deadline rather than a nag: pricing the model back-fills everything still on disk, but Claude Code prunes transcripts at ~30 days, and anything pruned first is gone.

Measured 2026-07-26T08:29Z against the live tree: **2,307 deduped assistant messages, 85 transcripts, $227.46**, growing ~11 msg/min because the sessions doing this work are themselves Opus 5. (Dedup key `(message.id, requestId)`; a raw line count runs ~2.6x higher since streaming chunks repeat the identity.)

## Verification

- Price confirmed against platform.claude.com; every other row in the table re-checked at the same time, and the source comment now cites what was actually verified rather than a stale skill cache.
- **Back-fill proven against an existing persisted state file** — ran master then this branch over one scratch `state.json`; deferred messages bank exactly once, re-runs don't double-count. This was the riskiest assumption.
- 19/19 tests pass. The new invariant guard was mutation-tested: adding `claude-opus-5-1` makes it fail with the offending pair.

## Known caveat, please read before deploying

The recovered $227.46 **will not appear in any windowed `$` panel**. A back-fill lands in a brand-new counter series, and `increase()`/`rate()` are last-minus-first over observed samples, so a series whose first sample is already large contributes zero. Precedent: the qwen back-fill of `8b2b3ae` reads `0.043208` cumulative on misaka while `increase(...[30d])` returns `0`. Only raw cumulative reads reflect it. Not fixable in PromQL — annotate the dashboard at deploy time if the figure needs to be visible.

## Follow-up not in this PR

`claude-opus-5` is a prefix of the whole future 5.x line, so a `claude-opus-5-1` at a different price would be priced silently at $5/$25 and would **not** trip the unpriced alert. Pre-existing property of the `startswith(known + "-")` rule (`claude-sonnet-5` and `claude-fable-5` carry it too), and the obvious table-invariant guard can't catch it — the real fix is a stricter suffix rule, which is a semantic change that belongs on its own. Written up in `ansible-scripts:docs/model-pricing-automation.md`; wants sequencing before Opus 5.1 ships.

Paired with `ansible-scripts#fix/claude-usage-scrape-interval`, which fixes the alert flapping that surfaced this.